### PR TITLE
Add config options to auto-add line breaks and escape HTML markup

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -16,15 +16,41 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Automatically link URL:s
+    | Automatically link URLs
     |--------------------------------------------------------------------------
     |
-    | This option controls the automatic anchor inserting on URL:s in your
+    | This option controls the automatic anchor inserting on URLs in your
     | markdown. If this option is true, all websites in your markdown
     | will automatically be turned into anchor tags in your output.
     |
     */
 
     'urls' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Escape HTML markup
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether or not HTML entities should be escaped.
+    | If this option is false, then users could be able to insert any
+    | arbitrary HTML/scripts which may lead to XSS vulnerabilities.
+    |
+    */
+
+    'escape_markup' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Automatically add line breaks
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the automatic insertion of single line breaks
+    | like GitHub Flavored Markdown (GFM). If this option is false,
+    | users must enter two line breaks to start a new paragraph.
+    |
+    */
+
+    'breaks' => false,
 
 ];

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -57,6 +57,8 @@ class MarkdownServiceProvider extends ServiceProvider
             $parsedown = new Parsedown;
 
             $parsedown->setUrlsLinked(config('markdown.urls'));
+            $parsedown->setMarkupEscaped(config('markdown.escape_markup'));
+            $parsedown->setBreaksEnabled(config('markdown.breaks'));
 
             return new Parser($parsedown);
         });


### PR DESCRIPTION
Closes https://github.com/andreasindal/laravel-markdown/issues/8

Both options are disabled by default for legacy/backwards compatibility.
