### PR TITLE
Use Parsedown safemode for better xss protection

### DIFF
--- a/config/markdown.php
+++ b/config/markdown.php
@@ -6,13 +6,14 @@ return [
     |--------------------------------------------------------------------------
     | Escape output
     |--------------------------------------------------------------------------
-    |
-    | This option controls whether or not JavaScript in anchor tags should be
-    | escaped or not, e.g. markdown like "[Link](javascript:alert('xss'))".
+    | Escape user-input within the HTML that it generates. Additionally apply
+    | sanitisation to additional scripting vectors (such as scripting link
+    | destinations) that are introduced by the markdown syntax itself.
+    | https://github.com/erusev/parsedown#security
     |
     */
 
-    'xss' => true,
+    'safe_mode' => true,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Drivers/ParsedownDriver.php
+++ b/src/Drivers/ParsedownDriver.php
@@ -49,6 +49,11 @@ class ParsedownDriver implements MarkdownDriver
 
     private function setOptions(array $config)
     {
+        // xss config for backwards compatibility
+        if (isset($config['safe_mode']) || isset($config['xss'])) {
+            $this->parser->setSafeMode(true);
+        }
+
         if (isset($config['urls'])) {
             $this->parser->setUrlsLinked($config['urls']);
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -66,19 +66,11 @@ class Parser
     }
 
     /**
-     * Escape any XSS attempts related to injecting JavaScript in anchor tags.
-     * Will only escape the string if the escape option is set to true in the
-     * config.
-     *
      * @param  string  $text
      * @return string
      */
     public function escape($text)
     {
-        if (config('markdown.xss')) {
-            return preg_replace('/(\[.*\])\(javascript:.*\)/', '$1(#)', $text);
-        }
-
         return $text;
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -59,19 +59,6 @@ class ParserTest extends TestCase
     }
 
     /** @test */
-    public function it_removes_javascript_from_links()
-    {
-        $mock = Mockery::mock(MarkdownDriver::class);
-        $parser = new Parser($mock);
-
-        $mock->shouldReceive('text')->with("[Link](#)")->andReturn("<p><a href=\"#\">Link</a></p>");
-
-        $html = $parser->parse("[Link](javascript:alert('xss'))");
-
-        $this->assertEquals("<p><a href=\"#\">Link</a></p>", $html);
-    }
-
-    /** @test */
     function it_removes_leading_white_space()
     {
         $mock = Mockery::mock(MarkdownDriver::class);


### PR DESCRIPTION
The current 'xss' option is very easily bypassed and offers no security, a simple example: 
```
[a](JaVaScRiPt:alert(1))
```

Therefore use Parsedown's safemode functionality: https://github.com/erusev/parsedown#security